### PR TITLE
Flip Y texture coordinate.

### DIFF
--- a/primitive-sphere.js
+++ b/primitive-sphere.js
@@ -48,7 +48,7 @@ function primitiveSphere (radius, opt) {
       normalize(tmpVec3, tmpVec3)
       normals.push(tmpVec3.slice())
 
-      uvs.push([ normalizedY, 1 - normalizedZ ])
+      uvs.push([ normalizedY, normalizedZ ])
     }
 
     if (zRotationStep > 0) {


### PR DESCRIPTION
I'm unifying UV coordinates across all `primitive-*` modules to match WebGL convention of 0,0 being at the bottom left. This is also matching ThreeJS and Unity.

It probably requires major version bump.

![screen shot 2017-04-03 at 15 48 15](https://cloud.githubusercontent.com/assets/171001/24615046/161bb8da-1885-11e7-864b-778dfad6f28d.jpg)
